### PR TITLE
add destdir to pxget

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: rpx
 Type: Package
 Title: R Interface to the ProteomeXchange Repository
-Version: 1.11.2
+Version: 1.11.3
 Authors@R: c(person(given = "Laurent", family = "Gatto",
 	            email = "lg390@cam.ac.uk", 
                     role = c("aut","cre")))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # rpx 1.11
 
+## CHANGES IN VERSION 1.11.3
+
+- `pxget` gains a `destdir` argument to specify the destination to which files
+    should be downloaded <2017-01-27 Fri>
+
 ## CHANGES IN VERSION 1.11.2
 
 - Update unit test to reflect upstream changes <2017-01-25 Wed>

--- a/R/px.R
+++ b/R/px.R
@@ -111,7 +111,7 @@ setMethod("pxfiles", "PXDataset",
 
 
 setMethod("pxget", "PXDataset",
-          function(object, list, force=FALSE, ...) {
+          function(object, list, force=FALSE, destdir=getwd(), ...) {
               fls <- pxfiles(object)
               url <- pxurl(object)
               if (missing(list)) 
@@ -126,6 +126,7 @@ setMethod("pxget", "PXDataset",
               if (length(toget) < 1)
                   stop("No files to download.")
               urls <- gsub(" ", "\ ", paste0(url, "/", toget))
+              toget <- file.path(destdir, toget)
               message("Downloading ", length(urls), " file",
                       ifelse(length(urls) > 1, "s", ""))
               for (i in 1:length(urls)) {

--- a/man/PXDataset-class.Rd
+++ b/man/PXDataset-class.Rd
@@ -48,15 +48,16 @@
     \item{pxfiles}{\code{signature(object = "PXDataset")}: return a
       \code{character} of all available files. }
 
-    \item{pxget}{\code{signature(object = "PXDataset", list, force =
-      FALSE, ...)}: downloads the files from the ProteomeXchange
-      repository. If \code{list} is missing, the file to be downloaded
-      can be selected from a menu. If \code{list = "all"}, all files are
-      downloaded. The file names, as returned by \code{pxfiles} can also
-      be used. Alternatively, a \code{logical} or \code{numeric} indices
-      can be used. All files will be downloaded in the working
-      directory. Unless \code{force} is set to \code{TRUE}, files are
-      not downloaded if already present in the working directory.
+    \item{pxget}{\code{signature(object = "PXDataset", list,
+      force = FALSE, destdir = getwd(), ...)}: downloads the files from
+      the ProteomeXchange repository. If \code{list} is missing, the file
+      to be downloaded can be selected from a menu. If \code{list = "all"},
+      all files are downloaded. The file names, as returned by \code{pxfiles}
+      can also be used. Alternatively, a \code{logical} or \code{numeric}
+      indices can be used. All files will be downloaded into the directory
+      specified by \code{destdir} (default is the current working
+      directory). Unless \code{force} is set to \code{TRUE}, files are
+      not downloaded if already present in the \code{destdir} directory.
       Additional parameters can be passed to \code{\link{download.file}}
       via \code{...}.  Invisibly returns the names of the downloaded
       files. }

--- a/tests/testthat/test_px.R
+++ b/tests/testthat/test_px.R
@@ -27,6 +27,18 @@ test_that("PXD000001", {
     expect_equal(length(Biostrings::readAAStringSet(fa)), 4499)
 })
 
+test_that("pxget uses destdir", {
+    ## create tempdir
+    tmpdir <- file.path(tempdir(), "PXD000001fasta")
+    dir.create(tmpdir, showWarnings=FALSE, recursive=TRUE)
+    on.exit(unlink(tmpdir, recursive=TRUE))
+
+    px <- PXDataset("PXD000001")
+    fa <- pxget(px, "erwinia_carotovora.fasta", destdir=tmpdir)
+
+    expect_equal(fa, file.path(tmpdir, "erwinia_carotovora.fasta"))
+    expect_equal(length(Biostrings::readAAStringSet(fa)), 4499)
+})
 
 test_that("PXD version", {
     p <- PXDataset("PXD000001")


### PR DESCRIPTION
Dear Laurent,

this PR adds an `destdir` argument to `pxget` to avoid downloading the files into the current working directory or the additional `setwd` calls. The default is `destdir = getwd()` so nothing really changed.

Best wishes,

Sebastian